### PR TITLE
Remove outdated note on recruitment page

### DIFF
--- a/src/pages/Recruitment/Recruitment.tsx
+++ b/src/pages/Recruitment/Recruitment.tsx
@@ -73,13 +73,6 @@ const Recruitment: React.FC = () =>{
             <h2 className={"center-text"}>Current Postings</h2>
             <JobPostings />
             <br />
-            <hr />
-            <p>
-              <b>Note:</b> With the Canadian Hyperloop Conference coming up on
-              May 27-29th, we have fewer positions available for the Spring 2022
-              term. We will have more positions available in the Fall 2022 term,
-              so we look forward to your applications then. Thanks!
-            </p>
           </>
         ) : (
           <FlexContainer>


### PR DESCRIPTION
Removes this note:

<img width="1195" alt="Screen Shot 2022-08-29 at 1 04 50 AM" src="https://user-images.githubusercontent.com/57576109/187126770-82ce5504-329a-45a3-8729-eb50cd8e3635.png">
