### PR TITLE
Fix: render new line white space for posting descriptions

### DIFF
--- a/src/components/RecruitmentForm/JobPosting.tsx
+++ b/src/components/RecruitmentForm/JobPosting.tsx
@@ -26,6 +26,10 @@ const LightHeader = styled.h6`
 `;
 const applicationForm = process.env.REACT_APP_APPLICATION_FORM_URL;
 
+const FormattedP = styled.p`
+  white-space: pre-line; // ensures spaces and line breaks get displayed
+`;
+
 const JobPosting: React.FC<JobPostingProps> = (props) => (
   <div>
     <a
@@ -54,7 +58,7 @@ const JobPosting: React.FC<JobPostingProps> = (props) => (
     <h6 style={{ color: '#010101', fontWeight: 'normal' }}>
       Deadline: {props.deadline}
     </h6>
-    <p>{props.description}</p>
+    <FormattedP>{props.description}</FormattedP>
     {props.tasks.length > 0 && (
       <>
         <div className="break" />


### PR DESCRIPTION
Addresses Electrical and Software posting issues in F22 recruitment

Before:
![image](https://user-images.githubusercontent.com/57576109/187506091-c580da63-d36a-4584-8d65-2faaa3966948.png)

After:
<img width="1210" alt="Screen Shot 2022-08-30 at 1 44 10 PM" src="https://user-images.githubusercontent.com/57576109/187506978-ed0e753e-c3d5-4a82-8978-3c538760d42e.png">