### PR TITLE
hide roster + don't display empty posting / sponsor sections

### DIFF
--- a/src/components/RecruitmentForm/JobPostingPage.tsx
+++ b/src/components/RecruitmentForm/JobPostingPage.tsx
@@ -3,6 +3,7 @@ import JobPosting from './JobPosting';
 import { useParams, useHistory, Redirect } from 'react-router';
 import usePostingPostingById from 'hooks/posting-by-id';
 import moment from 'moment';
+
 interface RouteParams {
   id: string;
 }
@@ -19,15 +20,11 @@ const JobPostingPage: React.FC = () => {
   const deadline = posting && moment
     .utc(posting.deadline)
     .local()
-    // !NOTE: Below line is needed for bnackwards compatibility. Remove when fall recruitment season ends. 
-    .hour(23).minute(59).second(59).millisecond(999)
 
   if (posting && (posting.closed || deadline.toDate().getTime() <= Date.now())) {
     return (<Redirect to='/recruitment' />);
   }
-  
-  
-  
+
   return (
     <div className="pageContainer">
       {posting && (
@@ -37,11 +34,11 @@ const JobPostingPage: React.FC = () => {
           term={`${posting.termSeason} ${posting.termYear}`}
           deadline={deadline.format('MMMM D, h:mmA')}
           description={posting.description}
-          tasks={posting.tasks.map((task) => task.task)}
-          requirements={posting.requirements.map((r) => r.requirement)}
-          additional={posting.info.map((i) => i.info)}
-          recommendedSkills={posting.recommendedSkills.map((i) => i.recommendedSkill)}
-          skillsToBeLearned={posting.skillsToBeLearned.map((i) => i.skillToBeLearned)}
+          tasks={posting.tasks.map((task) => task.task).filter((str) => str !== '')}
+          requirements={posting.requirements.map((r) => r.requirement).filter((str) => str !== '')}
+          additional={posting.info.map((i) => i.info).filter((str) => str !== '')}
+          recommendedSkills={posting.recommendedSkills.map((i) => i.recommendedSkill).filter((str) => str !== '')}
+          skillsToBeLearned={posting.skillsToBeLearned.map((i) => i.skillToBeLearned).filter((str) => str !== '')}
           timeCommitment={posting.timeCommitment}
         />
       )}

--- a/src/components/Sponsor/SponsorPage.tsx
+++ b/src/components/Sponsor/SponsorPage.tsx
@@ -13,37 +13,6 @@ const TransonicSponsor = styled(SponsorComponent)`
   }
 `;
 
-// interface ISponsor {
-//   image: {
-//     src: string;
-//     alt: string;
-//   };
-//   name: string;
-//   link: string;
-//   level: 'Hypersonic' | 'Transonic' | 'Supersonic' | 'Sonic';
-//   dateJoined: string;
-//   collaboration: string;
-//   video?: string;
-// }
-//#region
-// /* Move this to the CMS Eventually */
-// const sponsors: ISponsor[] = [
-//   {
-//   // {
-//   //   name: 'Dassult Systems',
-//   //   collaboration: 'Thank you for providing our team with 90 Solidworks 2020/2021 licenses. The mechanical team relies heavily on Solidworks (and Solidworks PDM) to design and simulate each and every component in the pod. This also provides an opportunity for our members to gain highly industry-relevant experience in CAD, FEA, and GD&T.',
-//   // },
-//   // {
-//   //   name: 'Metal Pros',
-//   //   collaboration: 'MetalPros provided us with your generous discount. We used this to purchase our aluminum tubing for our current pod’s frame.',
-//   //   dateJoined: 'Fall 2020',
-//   //   image: ,
-//   //   level: 'Supporter' // TODO Add in supporter tier
-//   // },
-// ];
-//#endregion
-
-
 const SponsorList: React.FC = () => {
   const { sponsors, sponsorTiers } = useSponsors();
   const [sponsor, setSponsor] = React.useState<Sponsor>();
@@ -141,7 +110,8 @@ const SponsorList: React.FC = () => {
             </Grid>
           ))}
       </Grid>
-      <h2>Supporters</h2>
+      {/* TODO: uncomment me once cms-side Supporters and Old Sponsor tiers work! */}
+      {/* <h2>Supporters</h2>
       <Grid
         className="TierWrapper"
         spacing={4}
@@ -177,7 +147,7 @@ const SponsorList: React.FC = () => {
               />
             </Grid>
           ))}
-      </Grid>
+      </Grid> */}
       <SponsorModal
         open={modalOpen}
         onClose={() => {

--- a/src/pages/Recruitment/Recruitment.tsx
+++ b/src/pages/Recruitment/Recruitment.tsx
@@ -86,7 +86,7 @@ const Recruitment: React.FC = () =>{
             <p>
               Do you have prior expertise in linear induction motors, high power PCB design, or other relevant technical topics? We'd love to learn from you as an advisor; reach out to us at <a href = "mailto: contact@waterloop.ca">contact@waterloop.ca</a> if you're interested!
             </p>
-            <SignUpButton onClick={() => window.open('http://wloop.ca/subscribe')} text="Sign up" backgroundColor="yellow" textColor="black"  />
+            <SignUpButton onClick={() => window.open('http://wloop.fly.dev/subscribe')} text="Sign up" backgroundColor="yellow" textColor="black"  />
           </FlexContainer>
         )}
       </div>

--- a/src/pages/Recruitment/RecruitmentFaq.tsx
+++ b/src/pages/Recruitment/RecruitmentFaq.tsx
@@ -73,7 +73,7 @@ const RecruitmentFaq = () => {
       <h3>Where can I apply?</h3>
       <ul>
         <li>Find all of our openings <a href="/recruitment">here</a></li>
-        <li>We typically open recruitment after exams in August, December, or April. If there are no openings available you can sign up to be notified <a href="http://wloop.ca/subscribe">here.</a></li>
+        <li>We typically open recruitment after exams in August, December, or April. If there are no openings available you can sign up to be notified <a href="http://wloop.fly.dev/subscribe">here.</a></li>
       </ul>
     </Container>
   );

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Hero from "components/Hero/General";
 import styled from "styled-components";
 import OurTeam from "components/OurTeam";
-import TeamsDisplayer from "components/TeamsDisplayer";
+// import TeamsDisplayer from "components/TeamsDisplayer";
 
 const ContentContainer = styled.div`
   display: block;
@@ -21,7 +21,7 @@ const Teams: React.FC = () => (
     <div className="pageContainer">
       <ContentContainer>
         <OurTeam />
-        <TeamsDisplayer initFilterSetting={0} />
+        {/* <TeamsDisplayer initFilterSetting={0} /> */}  // TODO: uncomment me when teamhub roster has been updated properly.
       </ContentContainer>
     </div>
   </div>


### PR DESCRIPTION
* Roster currently broken on main site (since no data yet), hiding for now.
* Some empty posting sections still get displayed with no bullet points, hiding those.
* Similar issue with sponsors, hiding those sections too.
* Change wloop.ca links to wloop.fly.dev.