### PR TITLE
Invalid sub-directories should direct to 404

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,20 +106,40 @@ class App extends React.Component<{}, State> {
         MainComponent: <Home />,
       }),
       this.generatePageMap({
+        path: '/the-flock/:id',
+        MainComponent: <ErrorPage />,
+      }),
+      this.generatePageMap({
         path: '/the-flock',
         MainComponent: <Flock />,
+      }),
+      this.generatePageMap({
+        path: '/team/:id',
+        MainComponent: <ErrorPage />,
       }),
       this.generatePageMap({
         path: '/team',
         MainComponent: <Team />,
       }),
       this.generatePageMap({
+        path: '/sponsors/:id',
+        MainComponent: <ErrorPage />,
+      }),
+      this.generatePageMap({
         path: '/sponsors',
         MainComponent: <Sponsors />,
       }),
       this.generatePageMap({
+        path: '/contact/:id',
+        MainComponent: <ErrorPage />,
+      }),
+      this.generatePageMap({
         path: '/contact',
         MainComponent: <Contact />,
+      }),
+      this.generatePageMap({
+        path: '/recruitment/:id',
+        MainComponent: <ErrorPage />,
       }),
       this.generatePageMap({
         path: '/recruitment',
@@ -152,6 +172,7 @@ class App extends React.Component<{}, State> {
         path: '/*',
         MainComponent: <Redirect to="/404" />,
       }),
+      
     ];
 
     return (


### PR DESCRIPTION
# [CLICKUP TICKET LINK] (https://app.clickup.com/t/20e3n9z)

## Summary
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Invalid sub-sub-directories on the main website should redirect to the 404 page, which is now fixed which previously was not directing to 404.

- added this.generatePageMap({
              path: '/sub-directories/:id',
              MainComponent: <ErrorPage />,
           }), for all sub-directories in the main router in App.tsx

## Type Of Change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested if invalid sub-directories got redirected to 404

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation/READ-ME/UMLS (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
